### PR TITLE
Fix modfactor calculation

### DIFF
--- a/SonificationEigenBasis.py
+++ b/SonificationEigenBasis.py
@@ -178,9 +178,11 @@ def SSEDynamicsSRK(PsiIn: np.ndarray, dt: float, tf: float,
     RhoOut[:, :, 0] = np.outer(PsiIn, PsiIn.conj())
     
     # Determine the frequency of saving data
-    modfactor = N / 2000
-    if modfactor < 1:
-        modfactor = 1  # Ensure at least every step is saved if N < 2000
+    # Determine how frequently to record data.  In the original MATLAB code the
+    # trajectory was sampled roughly 2000 times.  Using a floating point value
+    # for ``modfactor`` can lead to surprising behaviour when used with the
+    # modulus operator, so convert it to an integer explicitly.
+    modfactor = max(int(N // 2000), 1)
     
     # Initialize step counter
     m = 1  # Python uses 0-based indexing; m=1 corresponds to the second column

--- a/SpinHelix.py
+++ b/SpinHelix.py
@@ -106,10 +106,9 @@ def SSEDynamicsSRK_MultiL(PsiIn: np.ndarray, dt: float, tf: float,
     PsiOut[:, 0] = PsiIn
     RhoOut[:, :, 0] = np.outer(PsiIn, PsiIn.conjugate())
 
-    # Determine frequency of saving data
-    modfactor = N / 2000
-    if modfactor < 1:
-        modfactor = 1
+    # Determine how often results are stored.  Keeping ``modfactor`` as an
+    # integer avoids floating point comparisons when using the modulus operator.
+    modfactor = max(int(N // 2000), 1)
     m = 1
 
     for n in range(2, N + 1):


### PR DESCRIPTION
## Summary
- avoid float modulo in SonificationEigenBasis `SSEDynamicsSRK`
- avoid float modulo in SpinHelix `SSEDynamicsSRK_MultiL`

## Testing
- `python -m py_compile SonificationEigenBasis.py SpinHelix.py`

------
https://chatgpt.com/codex/tasks/task_e_685c145f9e28833298546513d511a1f0