### PR TITLE
Fix README filename reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Repository for the project: The sound of decoherence
 
 Ensure that FFmpeg is installed on your system. Then, execute the Python script by running:
 
-python SonificationEigenbasis.py
+python SonificationEigenBasis.py
 or 
 python SpinHelix.py
 This will generate all videos with accompanying sound.


### PR DESCRIPTION
## Summary
- fix the filename for the eigenbasis demo script in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c15aa9ebc8332a51268f8aaf3d01d